### PR TITLE
Adding missing dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ install complimentary libraries:
 
 install build dependencies:
 
-`sudo apt-get install libopenimageio-dev libglew-dev freeglut3-dev´
+`sudo apt-get install libopenimageio-dev libglew-dev freeglut3-dev`
 
 Also make sure you have the `opencl-dev` headers installed. Then create the Makefile:
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ install complimentary libraries:
 
 `sudo apt-get install g++`
 
-install OpenImageIO:
+install build dependencies:
 
-`sudo apt-get install libopenimageio-dev`
+`sudo apt-get install libopenimageio-dev libglew-dev freeglut3-dev´
 
-Create Makefile:
+Also make sure you have the `opencl-dev` headers installed. Then create the Makefile:
 
 `./Tools/premake/linux64/premake5 gmake`
 


### PR DESCRIPTION
Currently the README is missing install instructions that are preventing the library from being build on default configured systems.
This patch fixes that.